### PR TITLE
Kinda fixes cursor not falling in place while editing a file by not changing font styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.2 (07-07-2021)
+
+### Fixes
+
+- Mouse cursor not falling in correct place while editing a file. [Issue #6](https://github.com/ceoshikhar/better-github/issues/6) - Fixed by [PR #10](https://github.com/ceoshikhar/better-github/pull/10).
+
+- Stopped working on github gists. [Issue #8](https://github.com/ceoshikhar/better-github/issues/8) - Fixed by [PR #9](https://github.com/ceoshikhar/better-github/pull/9). Thanks to [Aahnik Daw](https://github.com/aahnik).
+
 # 1.0.1 (01-04-2021)
 
 ### Features

--- a/better-github.js
+++ b/better-github.js
@@ -21,6 +21,8 @@ function init() {
 
 // Apply the currently set font styles if they exist
 async function applyCurrentSetStyles() {
+  if (isUserEditingFile()) return; 
+
   const currentSetFontStyles = await getCurrentSetFontStyles();
   if (!currentSetFontStyles) return;
 
@@ -246,4 +248,39 @@ async function getCurrentSetFontStyles() {
   cache.fontSize = currentSetFontSize;
 
   return genFontStyles(currentSetFontName, currentSetFontSize);
+}
+
+// This is a cheeky solution to the issue where the code editor goes whack
+// mode when we change the font styles on the code lines inside the editor.
+//
+// So for the time being we will not change the font styles when a user is
+// editing a file on GitHub.
+//
+// Maybe in the future, if I get lucky( idk wtf is GitHub doing ) or someone 
+// in the world contributes and solves this issue where we can apply custom 
+// font styles to editor font without making it go insane, that would be nice.
+//
+// Untill then, Better GitHub won't do it's magic when user edits a file on
+// GitHub. Also, who does that? xD
+// Check - https://github.com/ceoshikhar/better-github/issues/6 for more info.
+function isUserEditingFile() {
+  function fileNameFromPath() {
+    const words     = window.location.pathname.split("/");
+    const len       = words.length;
+    // The file being viewed/edited on GitHub is the last word in the URL path.
+    const fileName  = words[len - 1];
+
+    return fileName;
+  }
+
+  // The word "edit" exists in the URL path if the user is editing the file.
+  const wordEditInPathExists = window.location.pathname.includes("edit");
+  const fileNameFromInputEl = document.querySelector('input[name=filename]')?.value;
+
+  // The name of the file being edited will be same in URL path and input element on page load.
+  if ((fileNameFromPath() === fileNameFromInputEl) && wordEditInPathExists) {
+    return true;
+  }
+
+  return false;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-github",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Enhance your code reading experience on GitHub",
   "author": {
     "name": "Shikhar Sharma",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -44,7 +44,7 @@ function result(text) {
 const chromeManifestContent = {
   "manifest_version": 2,
   "name": "Better Github",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Enhance your code reading experience on GitHub",
   "content_scripts": [
     {


### PR DESCRIPTION
Kinda fixes #6. It's not really a fix because we are literally stopping Better GitHub to do what it does the best when a user is editing a file.

Check the "code" section of this PR for a comment explaining why, what and how I am closing the issue #6  for time being.