### PR TITLE
feature: apply only wanted styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,36 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 1.1.0 (16-01-2022)
+
+### Features
+
+- Can provide just one styel property and it will apply that style property instead of making the user provide values for all the style properties. [PR #12](https://github.com/ceoshikhar/better-github/pull/12).
 
 # 1.0.3 (26-12-2021)
 
 ### Features
 
--   Can customize line height.
+- Can customize line height.
 
 # 1.0.2 (07-07-2021)
 
 ### Fixes
 
--   Mouse cursor not falling in correct place while editing a file. [Issue #6](https://github.com/ceoshikhar/better-github/issues/6) - Fixed by [PR #10](https://github.com/ceoshikhar/better-github/pull/10).
+- Mouse cursor not falling in correct place while editing a file. [Issue #6](https://github.com/ceoshikhar/better-github/issues/6) - Fixed by [PR #10](https://github.com/ceoshikhar/better-github/pull/10).
 
--   Stopped working on github gists. [Issue #8](https://github.com/ceoshikhar/better-github/issues/8) - Fixed by [PR #9](https://github.com/ceoshikhar/better-github/pull/9). Thanks to [Aahnik Daw](https://github.com/aahnik).
+- Stopped working on github gists. [Issue #8](https://github.com/ceoshikhar/better-github/issues/8) - Fixed by [PR #9](https://github.com/ceoshikhar/better-github/pull/9). Thanks to [Aahnik Daw](https://github.com/aahnik).
 
 # 1.0.1 (01-04-2021)
 
 ### Features
 
--   Support for Firefox. Released it as an official mozilla firefox [addon](https://addons.mozilla.org/en-US/firefox/addon/bettergithub)
--   Scripts to build/package the extension( zip ) and generate manifest.json
+- Support for Firefox. Released it as an official mozilla firefox [addon](https://addons.mozilla.org/en-US/firefox/addon/bettergithub)
+- Scripts to build/package the extension( zip ) and generate manifest.json
 
 ### Fixes and refactors
 
--   Extra scroll( overflow ) on `<body>` in Popup on Firefox
--   Refactor Popup CSS styles to `styles.css`
+- Extra scroll( overflow ) on `<body>` in Popup on Firefox
+- Refactor Popup CSS styles to `styles.css`
 
 # 1.0.0 (29-03-2021)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "better-github",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "description": "Enhance your code reading experience on GitHub",
     "author": {
         "name": "Shikhar Sharma",

--- a/popup.html
+++ b/popup.html
@@ -50,7 +50,6 @@
                     autocomplete="off"
                 />
             </div>
-            <p id="warning"><strong>*</strong> All fields are required</p>
             <br />
             <button id="apply-button" type="submit">APPLY</button>
             <button id="reset-button">RESET</button>

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,7 +25,7 @@
 
 // NOTE: Update the `version` here and in `package.json` whenever a new release
 // of the extension is published.
-const VERSION = "1.0.3";
+const VERSION = "1.1.0";
 
 const fs = require("fs");
 const childProcess = require("child_process");

--- a/styles.css
+++ b/styles.css
@@ -13,7 +13,7 @@ label {
     padding: 0;
     font-size: 1rem;
     color: RGB(42, 46, 47);
-    font-family: 'Poppins', sans-serif;
+    font-family: "Poppins", sans-serif;
 }
 
 h2 {
@@ -24,7 +24,7 @@ h2 {
 
 p {
     text-align: center;
-    font-family: 'Source Code Pro', monospace;
+    font-family: "Source Code Pro", monospace;
 }
 
 label {
@@ -40,7 +40,7 @@ form {
 }
 
 form input {
-    font-family: 'Source Code Pro', monospace;
+    font-family: "Source Code Pro", monospace;
     color: RGB(42, 46, 47);
     font-weight: normal;
     margin-top: 0.25em;
@@ -58,19 +58,13 @@ input::placeholder {
     opacity: 0.69;
 }
 
-#warning {
-    text-align: left;
-    font-size: 0.75rem;
-    margin-top: 0.5em;
-}
-
 button {
     width: 90%;
     padding: 0.5em 0.35em;
     font-size: 1.15rem;
     border: none;
     cursor: pointer;
-    font-family: 'Poppins', sans-serif;
+    font-family: "Poppins", sans-serif;
 }
 
 #apply-button {


### PR DESCRIPTION
There was a time when the styles would only apply if **all** of them were provided. 

It was very annoying. 

But luckily, now you can just set styles for whatever property (font name, font size, line height) you want. 

You can now just change the font name and not provide anything for font size and line height and it will apply the new font family.


PS - Some changes are due to prettier.
